### PR TITLE
feat: Reduce container image size

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,12 @@
     "config:base",
     ":preserveSemverRanges",
     ":disableDependencyDashboard"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["python"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    }
   ]
 }

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,3 +1,11 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
-python3 -m mumbleice -c $MUMBLEICE_CONFIG_FILE
+main() {
+  if [ "$1" = 'mumbleice' ] && [ "$(id -u)" = '0' ]; then
+    exec gosu mumbleice "$@"
+  fi
+
+  exec "$@"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

I've noticed the main two problems of the `bitcast/mumbleice:dev` container image
1. enormous size;
1. not working.

I want to reduce the size by using an alpine container image.
Make it work.

## Details

Here's the image size chart
| image | size |
| ---   | ---  |
| python:3.11 | 1.01GB |
| python:3.11 + ffmpeg | 1.39GB |
| python:3.11-slim | 130MB |
| python:3.11-slim + ffmpeg | 603MB |
| python:3.11-alpine | 52.5MB |
| python:3.11-alpine + ffmpeg | 179MB |
| alpine:3.19 | 7.4MB |
| alpine:3.19 + python + ffmpeg | 168MB |

I use *python:3.11-slim* because `pymumble` is incompatible with *python:3.12-slim*. ~For the same reason, I use *alpine:3.19*.~

The *python:3.11-slim* almost always provides the smaller image without significant changes to the container file, ~but *python:3.11-alpine* will give an even smaller image when you can properly configure it.~
~It would be sufficient to use *python:3.11-alpine* for my purpose, but it has a [long-living problem with `find_library`](https://github.com/python/cpython/issues/65821), so I have to use *alpine:3.19* instead.~

I think that using venv and multi-staged build is one of the most space-efficient ways to containerize a Python application. So, the resulting image is 614MB ~164MB - 10 times less than before~.

## Additionally

It's possible to specify the `STOPSIGNAL SIGINT` so the container will stop gracefully, but this problem should be a part of another PR that will add proper signal handling.
https://github.com/bitcastza/mumbleice/blob/bfc20b1058b9197fdea728bd0c48309c6a19eab8/mumbleice/bot.py#L65-L71